### PR TITLE
Run docker with --network=host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sconectl"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["SCONE", "confidential"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,7 @@ fn main() {
     let image = format!("{repo}/sconecli:latest");
 
     let mut s = format!(
-        r#"docker run --entrypoint="" -ti --rm {vol} {cas_config_dir_vol} {kubeconfig_vol} -e "SCONECTL_CAS_CONFIG={cas_config_dir_env}" -e "SCONECTL_REPO={repo}" -v "$HOME/.docker":"/root/.docker" -v "$HOME/.scone":"/root/.scone" -v "$PWD":"/wd" -w "/wd" {image}"#
+        r#"docker run --entrypoint="" -ti --network=host --rm {vol} {cas_config_dir_vol} {kubeconfig_vol} -e "SCONECTL_CAS_CONFIG={cas_config_dir_env}" -e "SCONECTL_REPO={repo}" -v "$HOME/.docker":"/root/.docker" -v "$HOME/.scone":"/root/.scone" -v "$PWD":"/wd" -w "/wd" {image}"#
     );
     for (i, arg) in args.iter().enumerate().skip(1) {
         if arg == "--help" && i == 1 {


### PR DESCRIPTION
Particularly useful for running init with minikube.

Signed-off-by: Matteus Silva <silvamatteus@lsd.ufcg.edu.br>